### PR TITLE
Add basic mouse-aim/strafing and improve jumping

### DIFF
--- a/PonyGame/Assets/Scripts/TSMovement.cs
+++ b/PonyGame/Assets/Scripts/TSMovement.cs
@@ -7,7 +7,10 @@ public class TSMovement : MonoBehaviour
 
     public float walkSpeed = 1.0f;
     public float runSpeed = 2.0f;
+    public float strafeSpeed = 1.0f;
     public float acceleration = 5.0f;
+    public float strafeAcceleration = 7.0f;
+    public float mouseLookSpeed = 0.8f;
     public float rotSpeed = 120.0f;
     public float jumpSpeed = 0.03f;
     public float gravityFraction = 0.02f;
@@ -24,6 +27,12 @@ public class TSMovement : MonoBehaviour
     public float ForwardSpeed
     {
         get { return m_forwardVelocity; }
+    }
+
+    private float m_strafeVelocity = 0;
+    public float StrafeSpeed
+    {
+        get { return m_strafeVelocity; }
     }
 
     private float m_angularVelocity = 0;
@@ -51,7 +60,29 @@ public class TSMovement : MonoBehaviour
         {
             MoveInputs inputs = new MoveInputs();
 
-            inputs.turn = Input.GetAxis("Horizontal");
+            // show and hide cursor as appropriate
+            if (Input.GetMouseButtonDown(1))
+            {
+                Cursor.lockState = CursorLockMode.Locked;
+                Cursor.visible = false;
+            }
+            else if (Input.GetMouseButtonUp(1))
+            {
+                Cursor.lockState = CursorLockMode.None;
+                Cursor.visible = true;
+            }
+
+            // if rmb held down, use mouse-view
+            if (Input.GetMouseButton(1))
+            {
+                inputs.turn = Input.GetAxis("Mouse X") * mouseLookSpeed;
+                inputs.strafe = Input.GetAxis("Horizontal");
+            }
+            else
+            {
+                inputs.turn = Input.GetAxis("Horizontal");
+                inputs.strafe = 0;
+            }
             inputs.forward = Input.GetAxis("Vertical");
             inputs.run = Input.GetKey(KeyCode.LeftShift) && Input.GetAxis("Vertical") > 0;
             inputs.jump = Input.GetButtonDown("Jump");
@@ -66,7 +97,8 @@ public class TSMovement : MonoBehaviour
     private void ExecuteMovement(MoveInputs inputs)
     {
         m_forwardVelocity = Mathf.MoveTowards(m_forwardVelocity, inputs.forward * (inputs.run ? runSpeed : walkSpeed), acceleration * Time.deltaTime);
-        Vector3 desiredMove = transform.forward * m_forwardVelocity * Time.deltaTime;
+        m_strafeVelocity = Mathf.MoveTowards(m_strafeVelocity, inputs.strafe * strafeSpeed, strafeAcceleration * Time.deltaTime);
+        Vector3 desiredMove = transform.forward * m_forwardVelocity * Time.deltaTime + transform.right * m_strafeVelocity * Time.deltaTime;
 
         m_angularVelocity = rotSpeed * inputs.turn;
 
@@ -174,6 +206,7 @@ public class MoveInputs
 {
     public float    turn        = 0;
     public float    forward     = 0;
+    public float    strafe      = 0;
     public bool     run         = false;
     public bool     jump        = false;
 }

--- a/PonyGame/Assets/Scripts/TSMovement.cs
+++ b/PonyGame/Assets/Scripts/TSMovement.cs
@@ -85,7 +85,7 @@ public class TSMovement : MonoBehaviour
             }
             inputs.forward = Input.GetAxis("Vertical");
             inputs.run = Input.GetKey(KeyCode.LeftShift) && Input.GetAxis("Vertical") > 0;
-            inputs.jump = Input.GetButtonDown("Jump");
+            inputs.jump = Input.GetButton("Jump");
 
             ExecuteMovement(inputs);
         }


### PR DESCRIPTION
This just adds a basic mouse-aim mode by holding down the right mouse button (similar to some other pony game I believe). It can be a little jumpy (might need to make sure it can't jump too much in a single frame?), but it works alright for now.

It also adds basic strafing support, since it makes sense to use `a/d` for that while we're using the mouse to aim. This does look a bit skodgy since the animations aren't setup to handle it yet, but I think it makes sense to strafe left and right while we're using mouse-aim.

I made it so when you hold the jump button down it'll just keep jumping continuously, rather than only once. I think it's more natural.

I've never done Unity before so feel free to point out any silly bugs or issues.

**edit:** I think it'd make sense to have the up/down affect the camera as well, but I'll play with that separately to this PR.
