### PR TITLE
Ignore unnecessary OS files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,62 @@
+### Windows ###
+# Windows image file caches
+Thumbs.db
+ehthumbs.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+
+### OSX ###
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+
+### Linux ###
+*~
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+
+### Unity ###
 [Ll]ibrary/
 [Tt]emp/
 [Oo]bj/
@@ -19,3 +78,4 @@
 
 # Unity3D Generated File On Crash Reports
 sysinfo.txt
+


### PR DESCRIPTION
Updates `.gitignore` to ignore unnecessary OS-specific files by default.
