### PR TITLE
Hide cursor by default and use left thumbstick to change runmode

### DIFF
--- a/PonyGame/Assets/Scripts/MainGUI.cs
+++ b/PonyGame/Assets/Scripts/MainGUI.cs
@@ -3,7 +3,7 @@ using System.Collections;
 
 public class MainGUI : MonoBehaviour
 {
-    public bool lockCursor = false; 
+    public bool lockCursor = true;
 
 	void Start ()
     {

--- a/PonyGame/Assets/Scripts/TSMovement.cs
+++ b/PonyGame/Assets/Scripts/TSMovement.cs
@@ -91,7 +91,7 @@ public class TSMovement : MonoBehaviour
                 inputs.forward = move.magnitude;
             }
 
-            m_run = Input.GetKeyDown(KeyCode.C) || device.Action3.IsPressed ? !m_run : m_run;
+            m_run = Input.GetKeyDown(KeyCode.C) || (device.LeftStick.State && device.LeftStick.HasChanged) ? !m_run : m_run;
             inputs.run = Input.GetKey(KeyCode.LeftShift) || device.RightTrigger.State ? !m_run : m_run;
             inputs.jump = (Input.GetKey(KeyCode.Space) && !device.Action4.State) || device.Action3.State;
 


### PR DESCRIPTION
Hides the cursor by default, which I think makes sense given the mouseaim we're doing. This also changes the gamepad controls to click in the left thumbstick to change from/to run and normal mode, since that's more standard and `Action3` conflicted with the jump button.
