### PR TITLE
Check whether the left stick is pressed down for runmode properly

### DIFF
--- a/PonyGame/Assets/Scripts/Characters/TSMovement.cs
+++ b/PonyGame/Assets/Scripts/Characters/TSMovement.cs
@@ -92,7 +92,7 @@ public class TSMovement : MonoBehaviour
                 inputs.forward = move.magnitude;
             }
 
-            m_run = Input.GetKeyDown(KeyCode.C) || (device.LeftStick.State && device.LeftStick.HasChanged) ? !m_run : m_run;
+            m_run = Input.GetKeyDown(KeyCode.C) || device.LeftStickButton.WasPressed ? !m_run : m_run;
             inputs.run = Input.GetKey(KeyCode.LeftShift) || device.RightTrigger.State ? !m_run : m_run;
             inputs.jump = (Input.GetKey(KeyCode.Space) && !device.Action4.State) || device.Action3.State;
 


### PR DESCRIPTION
Turns out I was checking whether the controller left stick had been moved as to whether to enable or disable the runmode. Silly me.

This just makes it check the correct button instead.
